### PR TITLE
Update ORSSerialPort.m

### DIFF
--- a/Source/ORSSerialPort.m
+++ b/Source/ORSSerialPort.m
@@ -97,7 +97,10 @@ static __strong NSMutableArray *allSerialPorts;
 
 + (void)initialize
 {
-	allSerialPorts = [[NSMutableArray alloc] init];
+	static dispatch_once_t once;
+    	dispatch_once(&once, ^{
+        	allSerialPorts = [[NSMutableArray alloc] init];
+    	});
 }
 
 + (void)addSerialPort:(ORSSerialPort *)port;


### PR DESCRIPTION
ORSSerialPort +(void)initialize called multiple times. Fixed this by using dispatch_once(). 

Reference:http://stackoverflow.com/questions/14110396/initialize-called-more-than-once
