### PR TITLE
Logs out actual error number, support for non-standard baud rates

### DIFF
--- a/Source/ORSSerialPort.m
+++ b/Source/ORSSerialPort.m
@@ -593,7 +593,7 @@ static __strong NSMutableArray *allSerialPorts;
 	
 	// TODO: Call delegate error handling method if this fails
 	int result = tcsetattr(self.fileDescriptor, TCSANOW, &options);
-	if (result != 0) NSLog(@"Unable to set options on %@: %i", self, result);
+	if (result != 0) NSLog(@"Unable to set options on %@: %i", self, errno);
 }
 
 + (io_object_t)deviceFromBSDPath:(NSString *)bsdPath;


### PR DESCRIPTION
the result is always -1. The actual error is stored in errno.