### PR TITLE
support for non standard baud rates if tcsetattr fails

### DIFF
--- a/Source/ORSSerialPort.m
+++ b/Source/ORSSerialPort.m
@@ -599,9 +599,16 @@ static __strong NSMutableArray *allSerialPorts;
 	// Set baud rate
 	cfsetspeed(&options, [[self baudRate] unsignedLongValue]);
 	
-	// TODO: Call delegate error handling method if this fails
 	int result = tcsetattr(self.fileDescriptor, TCSANOW, &options);
-	if (result != 0) NSLog(@"Unable to set options on %@: %i", self, result);
+    if (result != 0) {
+        // Try to set baud rate via ioctl if normal port settings fail
+        int new_baud = [[self baudRate] intValue];
+        result = ioctl(self.fileDescriptor, IOSSIOSPEED, &new_baud, 1);
+        if (result == -1) {
+            // Notify delegate of port error stored in errno
+            [self notifyDelegateOfPosixError];
+        }
+    }
 }
 
 + (io_object_t)deviceFromBSDPath:(NSString *)bsdPath;

--- a/Source/ORSSerialPortManager.m
+++ b/Source/ORSSerialPortManager.m
@@ -157,7 +157,7 @@ static ORSSerialPortManager *sharedInstance = nil;
 {
 	if (![name length]) return nil;
 	NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", @"name", name];
-	return [[self.availablePorts filteredArrayUsingPredicate:predicate] firstObject];
+	return [[self.availablePorts filteredArrayUsingPredicate:predicate] objectAtIndex:0];
 }
 
 #pragma mark -


### PR DESCRIPTION
update for pull request #46 as discussed there.

Support for non standard baud rates if setting port attributes fail as fallback including error handling and notifying delegate.

Successfully tested with Junsi iCharger (CP210x chipset) at 128000 baud.