### PR TITLE
Issues #75 and #71 - Fixes poor packet parsing performance with multiple installed descriptors due to unbounded growth of receive buffers.

### DIFF
--- a/Framework Project/ORSSerialPort Tests/ORSSerialPacketDescriptor_Tests.m
+++ b/Framework Project/ORSSerialPort Tests/ORSSerialPacketDescriptor_Tests.m
@@ -46,7 +46,10 @@
 {
 	NSData *prefix = [@"!" dataUsingEncoding:NSASCIIStringEncoding];
 	NSData *suffix = [@";" dataUsingEncoding:NSASCIIStringEncoding];
-	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithPrefix:prefix suffix:suffix userInfo:nil];
+	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithPrefix:prefix
+																					   suffix:suffix
+											 maximumPacketLength:5
+																					 userInfo:nil];
 	XCTAssertNotNil(descriptor, @"Creating packet descriptor with prefix and suffix failed.");
 	XCTAssertEqualObjects(descriptor.prefix, prefix, @"Desriptor prefix property incorrect.");
 	XCTAssertEqualObjects(descriptor.suffix, suffix, @"Desriptor suffix property incorrect.");
@@ -62,7 +65,10 @@
 
 - (void)testPrefixSuffixStrings
 {
-	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithPrefixString:@"!" suffixString:@";" userInfo:nil];
+	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithPrefixString:@"!"
+																					   suffixString:@";"
+																				maximumPacketLength:5
+																						   userInfo:nil];
 	XCTAssertNotNil(descriptor, @"Creating packet descriptor with prefix and suffix failed.");
 	XCTAssertEqualObjects(descriptor.prefix, [@"!" dataUsingEncoding:NSASCIIStringEncoding], @"Desriptor prefix property incorrect.");
 	XCTAssertEqualObjects(descriptor.suffix, [@";" dataUsingEncoding:NSASCIIStringEncoding], @"Desriptor suffix property incorrect.");
@@ -81,7 +87,10 @@
 	XCTestExpectation *expectation = [self expectationWithDescription:@"Missing suffix packet parsing expectation."];
 	NSDictionary *userInfo = @{[@";" dataUsingEncoding:NSASCIIStringEncoding] : expectation};
 	NSData *suffix = [@";" dataUsingEncoding:NSASCIIStringEncoding];
-	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithPrefix:nil suffix:suffix userInfo:userInfo];
+	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithPrefix:nil
+																					   suffix:suffix
+																		  maximumPacketLength:5
+																					 userInfo:userInfo];
 	XCTAssertNotNil(descriptor, @"Creating packet descriptor with prefix and suffix failed.");
 	XCTAssertEqualObjects(descriptor.suffix, suffix, @"Desriptor suffix property incorrect.");
 	XCTAssertNil(descriptor.prefix, @"Desriptor prefix property incorrect.");
@@ -108,7 +117,10 @@
 	XCTestExpectation *expectation = [self expectationWithDescription:@"Missing suffix packet parsing expectation."];
 	NSDictionary *userInfo = @{[@"!" dataUsingEncoding:NSASCIIStringEncoding] : expectation};
 	NSData *prefix = [@"!" dataUsingEncoding:NSASCIIStringEncoding];
-	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithPrefix:prefix suffix:nil userInfo:userInfo];
+	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithPrefix:prefix
+																					   suffix:nil
+																		  maximumPacketLength:5
+																					 userInfo:userInfo];
 	XCTAssertNotNil(descriptor, @"Creating packet descriptor with prefix and suffix failed.");
 	XCTAssertEqualObjects(descriptor.prefix, prefix, @"Desriptor prefix property incorrect.");
 	XCTAssertNil(descriptor.suffix, @"Desriptor suffix property incorrect.");
@@ -133,7 +145,9 @@
 - (void)testRegex
 {
 	NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^!.+;$" options:0 error:NULL];
-	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithRegularExpression:regex userInfo:nil];
+	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithRegularExpression:regex
+																					 maximumPacketLength:5
+																								userInfo:nil];
 	XCTAssertNotNil(descriptor, @"Creating packet descriptor with regular expression failed.");
 	XCTAssertEqualObjects(descriptor.regularExpression, regex, @"Descriptor regex property incorrect.");
 	
@@ -173,6 +187,7 @@
 	ORSSerialPacketDescriptor *descriptor1 = [self defaultPacketDescriptorWithUserInfo:userInfo1];
 	ORSSerialPacketDescriptor *descriptor2 = [[ORSSerialPacketDescriptor alloc] initWithPrefix:[@"$" dataUsingEncoding:NSASCIIStringEncoding]
 																						suffix:[@";" dataUsingEncoding:NSASCIIStringEncoding]
+																		   maximumPacketLength:5
 																					  userInfo:userInfo2];
 	[self.port startListeningForPacketsMatchingDescriptor:descriptor1];
 	[self.port startListeningForPacketsMatchingDescriptor:descriptor2];
@@ -240,6 +255,7 @@
 	ORSSerialPacketDescriptor *descriptor1 = [self defaultPacketDescriptorWithUserInfo:userInfo1];
 	ORSSerialPacketDescriptor *descriptor2 = [[ORSSerialPacketDescriptor alloc] initWithPrefix:[@"$" dataUsingEncoding:NSASCIIStringEncoding]
 																						suffix:[@"%" dataUsingEncoding:NSASCIIStringEncoding]
+																		   maximumPacketLength:5
 																					  userInfo:userInfo2];
 	[self.port startListeningForPacketsMatchingDescriptor:descriptor1];
 	[self.port startListeningForPacketsMatchingDescriptor:descriptor2];
@@ -298,6 +314,7 @@
 		ORSSerialPacketDescriptor *descriptor1 = [self defaultPacketDescriptorWithUserInfo:userInfo1];
 		ORSSerialPacketDescriptor *descriptor2 = [[ORSSerialPacketDescriptor alloc] initWithPrefix:[@"$ba" dataUsingEncoding:NSASCIIStringEncoding]
 																							suffix:[@";" dataUsingEncoding:NSASCIIStringEncoding]
+																			   maximumPacketLength:5
 																						  userInfo:nil];
 		
 		[self.port startListeningForPacketsMatchingDescriptor:descriptor1];
@@ -328,7 +345,7 @@
 {
 	NSData *prefix = [@"!" dataUsingEncoding:NSASCIIStringEncoding];
 	NSData *suffix = [@";" dataUsingEncoding:NSASCIIStringEncoding];
-	return [[ORSSerialPacketDescriptor alloc] initWithPrefix:prefix suffix:suffix userInfo:userInfo];
+	return [[ORSSerialPacketDescriptor alloc] initWithPrefix:prefix suffix:suffix maximumPacketLength:20 userInfo:userInfo];
 }
 
 #pragma mark - ORSSerialPortDelegate

--- a/Framework Project/ORSSerialPort.xcodeproj/project.pbxproj
+++ b/Framework Project/ORSSerialPort.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9D64D0E71B9CBC99009D1AEB /* ORSSerialBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D64D0E51B9CBC99009D1AEB /* ORSSerialBuffer.h */; };
+		9D64D0E81B9CBC99009D1AEB /* ORSSerialBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D64D0E61B9CBC99009D1AEB /* ORSSerialBuffer.m */; };
 		9D7472181B6D7767002D8B10 /* ORSSerialPort_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D7472171B6D7767002D8B10 /* ORSSerialPort_Tests.m */; };
 		9D7472191B6D7767002D8B10 /* ORSSerial.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DCA89121A2BB106009285EB /* ORSSerial.framework */; };
 		9D7472201B6D7787002D8B10 /* ORSSerialPacketDescriptor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D74721F1B6D7787002D8B10 /* ORSSerialPacketDescriptor_Tests.m */; };
@@ -34,6 +36,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9D64D0E51B9CBC99009D1AEB /* ORSSerialBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORSSerialBuffer.h; sourceTree = "<group>"; };
+		9D64D0E61B9CBC99009D1AEB /* ORSSerialBuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORSSerialBuffer.m; sourceTree = "<group>"; };
 		9D7472131B6D7767002D8B10 /* ORSSerialPort Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ORSSerialPort Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D7472161B6D7767002D8B10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9D7472171B6D7767002D8B10 /* ORSSerialPort_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORSSerialPort_Tests.m; sourceTree = "<group>"; };
@@ -74,6 +78,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9D64D0EA1B9CBCA4009D1AEB /* Private */ = {
+			isa = PBXGroup;
+			children = (
+				9D64D0E51B9CBC99009D1AEB /* ORSSerialBuffer.h */,
+				9D64D0E61B9CBC99009D1AEB /* ORSSerialBuffer.m */,
+			);
+			name = Private;
+			sourceTree = "<group>";
+		};
 		9D7472141B6D7767002D8B10 /* ORSSerialPort Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -132,6 +145,7 @@
 				9DCA89391A2BB1E2009285EB /* ORSSerialRequest.m */,
 				9DD6B1D01B5F4338000AB46E /* ORSSerialPacketDescriptor.h */,
 				9DD6B1D11B5F4338000AB46E /* ORSSerialPacketDescriptor.m */,
+				9D64D0EA1B9CBCA4009D1AEB /* Private */,
 			);
 			name = Source;
 			path = ../Source;
@@ -158,6 +172,7 @@
 				9DD6B1D21B5F4338000AB46E /* ORSSerialPacketDescriptor.h in Headers */,
 				9DCA89321A2BB15A009285EB /* ORSSerial.h in Headers */,
 				9DCA893C1A2BB1E2009285EB /* ORSSerialPortManager.h in Headers */,
+				9D64D0E71B9CBC99009D1AEB /* ORSSerialBuffer.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -270,6 +285,7 @@
 				9DD6B1D31B5F4338000AB46E /* ORSSerialPacketDescriptor.m in Sources */,
 				9DCA893B1A2BB1E2009285EB /* ORSSerialPort.m in Sources */,
 				9DCA893D1A2BB1E2009285EB /* ORSSerialPortManager.m in Sources */,
+				9D64D0E81B9CBC99009D1AEB /* ORSSerialBuffer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -451,6 +467,7 @@
 				9D74721D1B6D7767002D8B10 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		9DCA890C1A2BB106009285EB /* Build configuration list for PBXProject "ORSSerialPort" */ = {
 			isa = XCConfigurationList;

--- a/Framework Project/ORSSerialPort.xcodeproj/xcshareddata/xcbaselines/9D7472121B6D7767002D8B10.xcbaseline/3AB06FEE-1381-45AC-9379-B331E6DDAABC.plist
+++ b/Framework Project/ORSSerialPort.xcodeproj/xcshareddata/xcbaselines/9D7472121B6D7767002D8B10.xcbaseline/3AB06FEE-1381-45AC-9379-B331E6DDAABC.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>ORSSerialPacketDescriptor_Tests</key>
+		<dict>
+			<key>testPerformanceWithMultipleInstalledDescriptors</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.02</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Framework Project/ORSSerialPort.xcodeproj/xcshareddata/xcbaselines/9D7472121B6D7767002D8B10.xcbaseline/Info.plist
+++ b/Framework Project/ORSSerialPort.xcodeproj/xcshareddata/xcbaselines/9D7472121B6D7767002D8B10.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>3AB06FEE-1381-45AC-9379-B331E6DDAABC</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>3400</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>iMac13,2</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Source/ORSSerialBuffer.h
+++ b/Source/ORSSerialBuffer.h
@@ -1,0 +1,21 @@
+//
+//  ORSSerialBuffer.h
+//  ORSSerialPort
+//
+//  Created by Andrew Madsen on 9/6/15.
+//  Copyright (c) 2015 Open Reel Software. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ORSSerialBuffer : NSObject
+
+- (instancetype)initWithMaximumLength:(NSUInteger)maxLength NS_DESIGNATED_INITIALIZER;
+
+- (void)appendData:(NSData *)data;
+- (void)clearBuffer;
+
+@property (nonatomic, strong, readonly) NSData *data;
+@property (nonatomic, readonly) NSUInteger maximumLength;
+
+@end

--- a/Source/ORSSerialBuffer.m
+++ b/Source/ORSSerialBuffer.m
@@ -1,0 +1,56 @@
+//
+//  ORSSerialBuffer.m
+//  ORSSerialPort
+//
+//  Created by Andrew Madsen on 9/6/15.
+//  Copyright (c) 2015 Open Reel Software. All rights reserved.
+//
+
+#import "ORSSerialBuffer.h"
+
+@interface ORSSerialBuffer ()
+
+@property (nonatomic, strong) NSMutableData *internalBuffer;
+
+@end
+
+@implementation ORSSerialBuffer
+
+- (instancetype)init NS_UNAVAILABLE
+{
+	[NSException raise:NSInternalInconsistencyException format:@"Use -[ORSSerialBuffer initWithMaximumLength:]"];
+	return nil;
+}
+
+- (instancetype)initWithMaximumLength:(NSUInteger)maxLength
+{
+	self = [super init];
+	if (self) {
+		_internalBuffer = [NSMutableData data];
+		_maximumLength = maxLength;
+	}
+	return self;
+}
+
+- (void)appendData:(NSData *)data
+{
+	[self willChangeValueForKey:@"internalBuffer"];
+	[self.internalBuffer appendData:data];
+	if ([self.internalBuffer length] > self.maximumLength) {
+		NSRange rangeToDelete = NSMakeRange(0, [self.internalBuffer length] - self.maximumLength);
+		[self.internalBuffer replaceBytesInRange:rangeToDelete withBytes:NULL length:0];
+	}
+	[self didChangeValueForKey:@"internalBuffer"];
+}
+
+- (void)clearBuffer
+{
+	self.internalBuffer = [NSMutableData data];
+}
+
+#pragma mark - Properties
+
++ (NSSet *)keyPathsForValuesAffectingData { return [NSSet setWithObjects:@"internalData", nil]; }
+- (NSData *)data { return self.internalBuffer; }
+
+@end

--- a/Source/ORSSerialPacketDescriptor.h
+++ b/Source/ORSSerialPacketDescriptor.h
@@ -38,7 +38,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Block that parses input data and returns a packet extracted from that data, or nil
+ * Block that parses input data and returns YES if inputData consists of a valid packet, or NO
  * if inputData doesn't contain a valid packet.
  */
 typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
@@ -59,7 +59,7 @@ typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
  *  For request/response protocols, see ORSSerialRequest, etc.
  *
  *  For more information about ORSSerialPort's packet descriptor API, see the ORSSerialPort Packet Parsing
- *  Programming Guide at 
+ *  Programming Guide at
  */
 @interface ORSSerialPacketDescriptor : NSObject
 
@@ -72,23 +72,25 @@ typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
  *  or regular expression, a response evaulator block containing arbitrary validation code can be
  *  provided instead.
  *
+ *  @param maxPacketLength The maximum length of a valid packet. This value _must_ be correctly specified.
  *  @param userInfo          An arbitrary userInfo object.
  *  @param responseEvaluator A block used to evaluate whether received data constitutes a valid packet.
  *
  *  @return An initizliaized ORSSerialPacketDesciptor instance.
  *
- *  @see -initWithPrefix:suffix:userInfo:
- *  @see -initWithPrefixString:suffixString:userInfo:
- *  @see -initWithRegularExpression:userInfo:
+ *  @see -initWithPrefix:suffix:maximumPacketLength:userInfo:
+ *  @see -initWithPrefixString:suffixString:maximumPacketLength:userInfo:
+ *  @see -initWithRegularExpression:maximumPacketLength:userInfo:
  */
-- (instancetype)initWithUserInfo:(nullable id)userInfo
-			   responseEvaluator:(ORSSerialPacketEvaluator)responseEvaluator NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithMaximumPacketLength:(NSUInteger)maxPacketLength
+								   userInfo:(nullable id)userInfo
+						  responseEvaluator:(ORSSerialPacketEvaluator)responseEvaluator NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Creates an initializes an ORSSerialPacketDescriptor instance using a prefix and/or suffix.
  *
- *  If the packet format uses printable ASCII characters, -initWithPrefixString:suffixString:userInfo:
- *  may be more suitable.
+ *  If the packet format uses printable ASCII characters,
+ *  -initWithPrefixString:suffixString:maximumPacketLength:userInfo: may be more suitable.
  *
  *  @note Either prefix or suffix may be nil, but not both. If the suffix is nil,
  *  packets will be considered to consist solely of prefix. If either value is nil, packets
@@ -96,6 +98,7 @@ typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
  *
  *  @param prefix   An NSData instance containing a fixed packet prefix. May be nil.
  *  @param suffix   An NSData instance containing a fixed packet suffix. May be nil.
+ *  @param maxPacketLength The maximum length of a valid packet. This value _must_ be correctly specified.
  *  @param userInfo An arbitrary userInfo object. May be nil.
  *
  *  @return An initizliaized ORSSerialPacketDesciptor instance.
@@ -104,29 +107,32 @@ typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
  */
 - (instancetype)initWithPrefix:(nullable NSData *)prefix
 						suffix:(nullable NSData *)suffix
+		   maximumPacketLength:(NSUInteger)maxPacketLength
 					  userInfo:(nullable id)userInfo;
 
 /**
  *  Creates an initializes an ORSSerialPacketDescriptor instance using a prefix string and/or suffix string.
  *
  *  This method assumes that prefixString and suffixString are ASCII or UTF8 strings.
- *  If the packet format does not use printable ASCII characters, -initWithPrefix:suffix:userInfo:
+ *  If the packet format does not use printable ASCII characters, -initWithPrefix:suffix:maximumPacketLength:userInfo:
  *  may be more suitable.
  *
- *  @note Either prefixString or suffixString may be nil, but not both. If the suffix is nil, 
+ *  @note Either prefixString or suffixString may be nil, but not both. If the suffix is nil,
  *  packets will be considered to consist solely of prefix. If either value is nil, packets
  *  will be considred to consist soley of the the non-nil value.
  *
  *  @param prefixString A fixed packet prefix string. May be nil.
  *  @param suffixString A fixed packet suffix string. May be nil.
+ *  @param maxPacketLength The maximum length of a valid packet. This value _must_ be correctly specified.
  *  @param userInfo     An arbitrary userInfo object. May be nil.
  *
  *  @return An initizliaized ORSSerialPacketDesciptor instance.
  *
- *  @see -initWithPrefix:suffix:userInfo:
+ *  @see -initWithPrefix:suffix:maximumPacketLength:userInfo:
  */
 - (instancetype)initWithPrefixString:(nullable NSString *)prefixString
 						suffixString:(nullable NSString *)suffixString
+				 maximumPacketLength:(NSUInteger)maxPacketLength
 							userInfo:(nullable id)userInfo;
 
 /**
@@ -136,14 +142,17 @@ typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
  *  regular expression. For this reason, the regex should match as conservatively (smallest match) as possible.
  *
  *  Packets described by descriptors created using this method are assumed to be ASCII or UTF8 strings.
- *  If your packets are not naturally represented as strings, consider using -initWithUserInfo:responseEvaluator: instead.
+ *  If your packets are not naturally represented as strings, consider using
+ *  -initWithMaximumPacketLength:userInfo:responseEvaluator: instead.
  *
  *  @param regex    An NSRegularExpression instance for which valid packets are a match.
+ *  @param maxPacketLength The maximum length of a valid packet. This value _must_ be correctly specified.
  *  @param userInfo An arbitrary userInfoObject. May be nil.
  *
  *  @return An initizliaized ORSSerialPacketDesciptor instance.
  */
 - (instancetype)initWithRegularExpression:(NSRegularExpression *)regex
+					  maximumPacketLength:(NSUInteger)maxPacketLength
 								 userInfo:(nullable id)userInfo;
 
 /**
@@ -157,7 +166,7 @@ typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
 - (BOOL)dataIsValidPacket:(nullable NSData *)packetData;
 
 /**
- *  The prefix for packets described by the receiver. Will be nil for packet 
+ *  The prefix for packets described by the receiver. Will be nil for packet
  *  descriptors not created using one of the prefix/suffix initializer methods.
  */
 @property (nonatomic, strong, readonly, nullable) NSData *prefix;
@@ -173,6 +182,11 @@ typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
  *  for packet descriptors not created using -initWithRegularExpression:userInfo:.
  */
 @property (nonatomic, strong, readonly, nullable) NSRegularExpression *regularExpression;
+
+/**
+ *  The maximum lenght of a packet described by the receiver.
+ */
+@property (nonatomic, readonly) NSUInteger maximumPacketLength;
 
 /**
  *  Arbitrary object (e.g. NSDictionary) used to store additional data

--- a/Source/ORSSerialPacketDescriptor.m
+++ b/Source/ORSSerialPacketDescriptor.m
@@ -54,13 +54,23 @@
 - (instancetype)initWithPrefix:(NSData *)prefix suffix:(NSData *)suffix userInfo:(id)userInfo
 {
 	self = [self initWithUserInfo:userInfo responseEvaluator:^BOOL(NSData *data) {
-		NSRange fullRange = NSMakeRange(0, [data length]);
-		NSRange prefixRange = NSMakeRange(0, 0);
-		if (prefix) prefixRange = [data rangeOfData:prefix options:NSDataSearchAnchored range:fullRange];
-		NSRange suffixRange = NSMakeRange([data length]-1, 0);
-		if (suffix) suffixRange = [data rangeOfData:suffix options:NSDataSearchAnchored | NSDataSearchBackwards range:fullRange];
+		if (prefix == nil && suffix == nil) { return NO; }
+		if (prefix && [prefix length] > [data length]) { return NO; }
+		if (suffix && [suffix length] > [data length]) { return NO; }
 		
-		return prefixRange.location != NSNotFound && suffixRange.location != NSNotFound;
+		for (NSUInteger i=0; i<[prefix length]; i++) {
+			uint8_t prefixByte = ((uint8_t *)[prefix bytes])[i];
+			uint8_t dataByte = ((uint8_t *)[data bytes])[i];
+			if (prefixByte != dataByte) { return NO; }
+		}
+		
+		for (NSUInteger i=0; i<[suffix length]; i++) {
+			uint8_t suffixByte = ((uint8_t *)[suffix bytes])[([suffix length]-1-i)];
+			uint8_t dataByte = ((uint8_t *)[data bytes])[([data length]-1-i)];
+			if (suffixByte != dataByte) { return NO; }
+		}
+		
+		return YES;
 	}];
 	if (self) {
 		_prefix = prefix;

--- a/Source/ORSSerialPort.m
+++ b/Source/ORSSerialPort.m
@@ -565,6 +565,8 @@ static __strong NSMutableArray *allSerialPorts;
 // Must only be called on requestHandlingQueue
 - (void)checkResponseToPendingRequestAndContinueIfValidWithReceivedByte:(NSData *)byte
 {
+	if (!self.pendingRequest) return; // Nothing to do
+	
 	ORSSerialPacketDescriptor *packetDescriptor = self.pendingRequest.responseDescriptor;
 	
 	if (!byte) {

--- a/Source/ORSSerialRequest.h
+++ b/Source/ORSSerialRequest.h
@@ -68,23 +68,6 @@ NS_ASSUME_NONNULL_BEGIN
 					responseDescriptor:(nullable ORSSerialPacketDescriptor *)responseDescriptor;
 
 /**
- *  Creates and initializes an ORSSerialRequest instance.
- *
- *  @param dataToSend        The data to be sent on the serial port.
- *  @param userInfo          An arbitrary userInfo object.
- *  @param timeout			 The maximum amount of time in seconds to wait for a response. Pass -1.0 to wait indefinitely.
- *  @param responseEvaluator A block used to evaluate whether received data constitutes a valid response to the request.
- *  May be nil. If responseEvaluator is nil, the request is assumed not to require a response, and the next request in the queue will
- *  be sent immediately.
- *
- *  @return An initialized ORSSerialRequest instance.
- */
-+ (instancetype)requestWithDataToSend:(NSData *)dataToSend
-							 userInfo:(nullable id)userInfo
-					  timeoutInterval:(NSTimeInterval)timeout
-					responseEvaluator:(nullable ORSSerialPacketEvaluator)responseEvaluator;
-
-/**
  *  Initializes an ORSSerialRequest instance.
  *
  *  @param dataToSend			The data to be sent on the serial port.
@@ -100,23 +83,6 @@ NS_ASSUME_NONNULL_BEGIN
 						  userInfo:(nullable id)userInfo
 				   timeoutInterval:(NSTimeInterval)timeout
 				 responseDescriptor:(nullable ORSSerialPacketDescriptor *)responseDescriptor;
-
-/**
- *  Initializes an ORSSerialRequest instance.
- *
- *  @param dataToSend        The data to be sent on the serial port.
- *  @param userInfo          An arbitrary userInfo object.
- *  @param timeout			 The maximum amount of time in seconds to wait for a response. Pass -1.0 to wait indefinitely.
- *  @param responseEvaluator A block used to evaluate whether received data constitutes a valid response to the request.
- *  May be nil. If responseEvaluator is nil, the request is assumed not to require a response, and the next request in the queue will
- *  be sent immediately.
- *
- *  @return An initialized ORSSerialRequest instance.
- */
-- (instancetype)initWithDataToSend:(NSData *)dataToSend
-						  userInfo:(nullable id)userInfo
-				   timeoutInterval:(NSTimeInterval)timeout
-				 responseEvaluator:(nullable ORSSerialPacketEvaluator)responseEvaluator;
 
 /**
  *  Data to be sent on the serial port when the receiver is sent.
@@ -151,6 +117,43 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Deprecated
 
 @interface ORSSerialRequest (Deprecated)
+
+/**
+ *  @deprecated Use +requestWithDataToSend:userInfo:timeoutInterval:responseDescriptor: instead.
+ *
+ *  Creates and initializes an ORSSerialRequest instance.
+ *
+ *  @param dataToSend        The data to be sent on the serial port.
+ *  @param userInfo          An arbitrary userInfo object.
+ *  @param timeout			 The maximum amount of time in seconds to wait for a response. Pass -1.0 to wait indefinitely.
+ *  @param responseEvaluator A block used to evaluate whether received data constitutes a valid response to the request.
+ *  May be nil. If responseEvaluator is nil, the request is assumed not to require a response, and the next request in the queue will
+ *  be sent immediately.
+ *
+ *  @return An initialized ORSSerialRequest instance.
+ */
++ (instancetype)requestWithDataToSend:(NSData *)dataToSend
+							 userInfo:(nullable id)userInfo
+					  timeoutInterval:(NSTimeInterval)timeout
+					responseEvaluator:(nullable ORSSerialPacketEvaluator)responseEvaluator DEPRECATED_ATTRIBUTE;
+
+/**
+ *  @deprecated Use -initWithDataToSend:userInfo:timeoutInterval:responseDescriptor: instead.
+ *  Initializes an ORSSerialRequest instance.
+ *
+ *  @param dataToSend        The data to be sent on the serial port.
+ *  @param userInfo          An arbitrary userInfo object.
+ *  @param timeout			 The maximum amount of time in seconds to wait for a response. Pass -1.0 to wait indefinitely.
+ *  @param responseEvaluator A block used to evaluate whether received data constitutes a valid response to the request.
+ *  May be nil. If responseEvaluator is nil, the request is assumed not to require a response, and the next request in the queue will
+ *  be sent immediately.
+ *
+ *  @return An initialized ORSSerialRequest instance.
+ */
+- (instancetype)initWithDataToSend:(NSData *)dataToSend
+						  userInfo:(nullable id)userInfo
+				   timeoutInterval:(NSTimeInterval)timeout
+				 responseEvaluator:(nullable ORSSerialPacketEvaluator)responseEvaluator DEPRECATED_ATTRIBUTE;
 
 /**
  *  @deprecated Use the receiver's responseDescriptor object's -dataIsValidPacket: method instead.

--- a/Source/ORSSerialRequest.m
+++ b/Source/ORSSerialRequest.m
@@ -86,7 +86,7 @@
 				   timeoutInterval:(NSTimeInterval)timeout
 				 responseEvaluator:(ORSSerialPacketEvaluator)responseEvaluator;
 {
-	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithMaximumPacketLength:NSUIntegerMax
+	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithMaximumPacketLength:NSIntegerMax
 																								  userInfo:nil
 																						 responseEvaluator:responseEvaluator];
 	return [self initWithDataToSend:dataToSend userInfo:userInfo timeoutInterval:timeout responseDescriptor:descriptor];

--- a/Source/ORSSerialRequest.m
+++ b/Source/ORSSerialRequest.m
@@ -47,14 +47,6 @@
 	return [[self alloc] initWithDataToSend:dataToSend userInfo:userInfo timeoutInterval:timeout responseDescriptor:responseDescriptor];
 }
 
-+ (instancetype)requestWithDataToSend:(NSData *)dataToSend
-							 userInfo:(id)userInfo
-					  timeoutInterval:(NSTimeInterval)timeout
-					responseEvaluator:(ORSSerialPacketEvaluator)responseEvaluator;
-{
-	return [[self alloc] initWithDataToSend:dataToSend userInfo:userInfo timeoutInterval:timeout responseEvaluator:responseEvaluator];
-}
-
 - (instancetype)initWithDataToSend:(NSData *)dataToSend
 									userInfo:(id)userInfo
 							 timeoutInterval:(NSTimeInterval)timeout
@@ -73,18 +65,31 @@
 	return self;
 }
 
+- (NSString *)description
+{
+	return [NSString stringWithFormat:@"%@ data: %@ userInfo: %@ timeout interval: %f", [super description], self.dataToSend, self.userInfo, self.timeoutInterval];
+}
+
+@end
+
+@implementation ORSSerialRequest (Deprecated)
+
++ (instancetype)requestWithDataToSend:(NSData *)dataToSend
+							 userInfo:(id)userInfo
+					  timeoutInterval:(NSTimeInterval)timeout
+					responseEvaluator:(ORSSerialPacketEvaluator)responseEvaluator;
+{
+	return [[self alloc] initWithDataToSend:dataToSend userInfo:userInfo timeoutInterval:timeout responseEvaluator:responseEvaluator];
+}
 - (instancetype)initWithDataToSend:(NSData *)dataToSend
 						  userInfo:(id)userInfo
 				   timeoutInterval:(NSTimeInterval)timeout
 				 responseEvaluator:(ORSSerialPacketEvaluator)responseEvaluator;
 {
-	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithUserInfo:nil responseEvaluator:responseEvaluator];
+	ORSSerialPacketDescriptor *descriptor = [[ORSSerialPacketDescriptor alloc] initWithMaximumPacketLength:NSUIntegerMax
+																								  userInfo:nil
+																						 responseEvaluator:responseEvaluator];
 	return [self initWithDataToSend:dataToSend userInfo:userInfo timeoutInterval:timeout responseDescriptor:descriptor];
-}
-
-- (NSString *)description
-{
-	return [NSString stringWithFormat:@"%@ data: %@ userInfo: %@ timeout interval: %f", [super description], self.dataToSend, self.userInfo, self.timeoutInterval];
 }
 
 - (BOOL)dataIsValidResponse:(NSData *)responseData


### PR DESCRIPTION
The underlying problem being fixed here is that with multiple installed packet descriptors, and packets of one type predominantly being received, the buffers for the other descriptor(s) grow without bound (see also #71), and time spent parsing through those buffers increases with every additional byte received.

The solution here solves this problem by including a maximumPacketLength on ORSSerialPacketDescriptor. This is used to set the maximum length of the receive buffer used for each descriptor, thereby limiting its ability to fill up with "garbage" data which will never be successfully parsed out.