### PR TITLE
Fix broken examples - swift 2.0

### DIFF
--- a/Examples/CommandLineDemo/Objective-C/CommandLineDemo.xcodeproj/project.pbxproj
+++ b/Examples/CommandLineDemo/Objective-C/CommandLineDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2788B8061BA05FFD0018C0E7 /* ORSSerialBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2788B8051BA05FFD0018C0E7 /* ORSSerialBuffer.m */; settings = {ASSET_TAGS = (); }; };
 		9D2B580C1ADC16E200B08D53 /* ORSSerialPort.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B58091ADC16E200B08D53 /* ORSSerialPort.m */; };
 		9D2B580D1ADC16E200B08D53 /* ORSSerialPortManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B580B1ADC16E200B08D53 /* ORSSerialPortManager.m */; };
 		9D2D68F71AC8524E00779F24 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D2D68F61AC8524E00779F24 /* IOKit.framework */; };
@@ -26,6 +27,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2788B8041BA05FFD0018C0E7 /* ORSSerialBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ORSSerialBuffer.h; path = ../../../../Source/ORSSerialBuffer.h; sourceTree = "<group>"; };
+		2788B8051BA05FFD0018C0E7 /* ORSSerialBuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ORSSerialBuffer.m; path = ../../../../Source/ORSSerialBuffer.m; sourceTree = "<group>"; };
 		9D2B58081ADC16E200B08D53 /* ORSSerialPort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ORSSerialPort.h; path = ../../../../Source/ORSSerialPort.h; sourceTree = "<group>"; };
 		9D2B58091ADC16E200B08D53 /* ORSSerialPort.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ORSSerialPort.m; path = ../../../../Source/ORSSerialPort.m; sourceTree = "<group>"; };
 		9D2B580A1ADC16E200B08D53 /* ORSSerialPortManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ORSSerialPortManager.h; path = ../../../../Source/ORSSerialPortManager.h; sourceTree = "<group>"; };
@@ -55,6 +58,8 @@
 				9D2B58091ADC16E200B08D53 /* ORSSerialPort.m */,
 				9D2B580A1ADC16E200B08D53 /* ORSSerialPortManager.h */,
 				9D2B580B1ADC16E200B08D53 /* ORSSerialPortManager.m */,
+				2788B8041BA05FFD0018C0E7 /* ORSSerialBuffer.h */,
+				2788B8051BA05FFD0018C0E7 /* ORSSerialBuffer.m */,
 			);
 			name = ORSSerialPort;
 			sourceTree = "<group>";
@@ -155,6 +160,7 @@
 			files = (
 				9D2B580D1ADC16E200B08D53 /* ORSSerialPortManager.m in Sources */,
 				9DF0453E1678336E00DA0CDA /* main.m in Sources */,
+				2788B8061BA05FFD0018C0E7 /* ORSSerialBuffer.m in Sources */,
 				9D2B580C1ADC16E200B08D53 /* ORSSerialPort.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/CommandLineDemo/Swift/CommandLineDemo.xcodeproj/project.pbxproj
+++ b/Examples/CommandLineDemo/Swift/CommandLineDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2720C0F11BA0612D00CC2BE3 /* ORSSerialBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2720C0F01BA0612D00CC2BE3 /* ORSSerialBuffer.m */; settings = {ASSET_TAGS = (); }; };
 		9D2B58071ADC16B500B08D53 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B58061ADC16B500B08D53 /* main.swift */; };
 		9D2B58141ADC170C00B08D53 /* ORSSerialPort.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B58111ADC170C00B08D53 /* ORSSerialPort.m */; };
 		9D2B58151ADC170C00B08D53 /* ORSSerialPortManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B58131ADC170C00B08D53 /* ORSSerialPortManager.m */; };
@@ -27,6 +28,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2720C0EF1BA0612D00CC2BE3 /* ORSSerialBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ORSSerialBuffer.h; path = ../../../../Source/ORSSerialBuffer.h; sourceTree = "<group>"; };
+		2720C0F01BA0612D00CC2BE3 /* ORSSerialBuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ORSSerialBuffer.m; path = ../../../../Source/ORSSerialBuffer.m; sourceTree = "<group>"; };
 		9D2B57FB1ADC165D00B08D53 /* CommandLineDemo */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = CommandLineDemo; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D2B58061ADC16B500B08D53 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		9D2B580F1ADC170C00B08D53 /* CommandLineDemo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CommandLineDemo-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -84,6 +87,8 @@
 				9D2B58111ADC170C00B08D53 /* ORSSerialPort.m */,
 				9D2B58121ADC170C00B08D53 /* ORSSerialPortManager.h */,
 				9D2B58131ADC170C00B08D53 /* ORSSerialPortManager.m */,
+				2720C0EF1BA0612D00CC2BE3 /* ORSSerialBuffer.h */,
+				2720C0F01BA0612D00CC2BE3 /* ORSSerialBuffer.m */,
 				9DFF14871B94E396004B42B3 /* ORSSerialRequest.h */,
 				9DFF14881B94E396004B42B3 /* ORSSerialRequest.m */,
 				9DFF14841B94E38D004B42B3 /* ORSSerialPacketDescriptor.h */,
@@ -152,6 +157,7 @@
 			files = (
 				9D2B58151ADC170C00B08D53 /* ORSSerialPortManager.m in Sources */,
 				9DFF14861B94E38D004B42B3 /* ORSSerialPacketDescriptor.m in Sources */,
+				2720C0F11BA0612D00CC2BE3 /* ORSSerialBuffer.m in Sources */,
 				9D2B58071ADC16B500B08D53 /* main.swift in Sources */,
 				9D2B58141ADC170C00B08D53 /* ORSSerialPort.m in Sources */,
 				9DFF14891B94E396004B42B3 /* ORSSerialRequest.m in Sources */,

--- a/Examples/CommandLineDemo/Swift/Sources/main.swift
+++ b/Examples/CommandLineDemo/Swift/Sources/main.swift
@@ -43,7 +43,7 @@ struct UserPrompter {
 	}
 	
 	func printPrompt() {
-		print("\n> ", appendNewline: false)
+		print("\n> ", terminator: "")
 	}
 	
 	func promptForSerialPort() {
@@ -57,7 +57,7 @@ struct UserPrompter {
 	}
 	
 	func promptForBaudRate() {
-		print("\nPlease enter a baud rate: ", appendNewline: false);
+		print("\nPlease enter a baud rate: ", terminator: "");
 	}
 }
 
@@ -111,7 +111,7 @@ class StateMachine : NSObject, ORSSerialPortDelegate {
 		selectionString = selectionString.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
 		if let baudRate = Int(selectionString) {
 			self.serialPort?.baudRate = baudRate
-			print("Baud rate set to \(baudRate)", appendNewline: false)
+			print("Baud rate set to \(baudRate)", terminator: "")
 			return true
 		} else {
 			return false
@@ -131,13 +131,13 @@ class StateMachine : NSObject, ORSSerialPortDelegate {
 			switch self.currentState {
 			case .WaitingForPortSelectionState(let availablePorts):
 				if !setupAndOpenPortWithSelectionString(string, availablePorts: availablePorts) {
-					print("\nError: Invalid port selection.", appendNewline: false)
+					print("\nError: Invalid port selection.", terminator: "")
 					prompter.promptForSerialPort()
 					return
 				}
 			case .WaitingForBaudRateInputState:
 				if !setBaudRateOnPortWithString(string) {
-					print("\nError: Invalid baud rate. Baud rate should consist only of numeric digits.", appendNewline: false);
+					print("\nError: Invalid baud rate. Baud rate should consist only of numeric digits.", terminator: "")
 					prompter.promptForBaudRate();
 					return;
 				}
@@ -156,7 +156,7 @@ class StateMachine : NSObject, ORSSerialPortDelegate {
 	
 	func serialPort(serialPort: ORSSerialPort, didReceiveData data: NSData) {
 		if let string = NSString(data: data, encoding: NSUTF8StringEncoding) {
-			print("\nReceived: \"\(string)\" \(data)", appendNewline: false)
+			print("\nReceived: \"\(string)\" \(data)", terminator: "")
 		}
 		prompter.printPrompt()
 	}
@@ -170,7 +170,7 @@ class StateMachine : NSObject, ORSSerialPortDelegate {
 	}
 	
 	func serialPortWasOpened(serialPort: ORSSerialPort) {
-		print("Serial port \(serialPort) was opened", appendNewline: false)
+		print("Serial port \(serialPort) was opened", terminator: "")
 		prompter.promptForBaudRate()
 		currentState = .WaitingForBaudRateInputState
 	}

--- a/Examples/ORSSerialPortDemo/Objective-C/ORSSerialPortDemo.xcodeproj/project.pbxproj
+++ b/Examples/ORSSerialPortDemo/Objective-C/ORSSerialPortDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2788B8001BA05EFC0018C0E7 /* ORSSerialBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2788B7FF1BA05EFC0018C0E7 /* ORSSerialBuffer.m */; settings = {ASSET_TAGS = (); }; };
 		9D52392E1AC859DF00AEB75F /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D52392D1AC859DF00AEB75F /* IOKit.framework */; };
 		9D5239301AC859E700AEB75F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D52392F1AC859E700AEB75F /* Cocoa.framework */; };
 		9D66D81D159BCAB800EE6D09 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9D66D81B159BCAB800EE6D09 /* InfoPlist.strings */; };
@@ -33,6 +34,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2788B7FE1BA05EFC0018C0E7 /* ORSSerialBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORSSerialBuffer.h; sourceTree = "<group>"; };
+		2788B7FF1BA05EFC0018C0E7 /* ORSSerialBuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORSSerialBuffer.m; sourceTree = "<group>"; };
 		9D52392D1AC859DF00AEB75F /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		9D52392F1AC859E700AEB75F /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		9D66D80E159BCAB800EE6D09 /* ORSSerialPortDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ORSSerialPortDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -131,6 +134,8 @@
 				9D66D835159BCC2F00EE6D09 /* ORSSerialPort.m */,
 				9D66D836159BCC2F00EE6D09 /* ORSSerialPortManager.h */,
 				9D66D837159BCC2F00EE6D09 /* ORSSerialPortManager.m */,
+				2788B7FE1BA05EFC0018C0E7 /* ORSSerialBuffer.h */,
+				2788B7FF1BA05EFC0018C0E7 /* ORSSerialBuffer.m */,
 			);
 			name = ORSSerialPort;
 			path = ../../../Source;
@@ -204,6 +209,7 @@
 			files = (
 				9D66D81F159BCAB800EE6D09 /* main.m in Sources */,
 				9D66D826159BCAB900EE6D09 /* ORSAppDelegate.m in Sources */,
+				2788B8001BA05EFC0018C0E7 /* ORSSerialBuffer.m in Sources */,
 				9D66D838159BCC2F00EE6D09 /* ORSSerialPort.m in Sources */,
 				9D66D839159BCC2F00EE6D09 /* ORSSerialPortManager.m in Sources */,
 				9D66D83D159BCC6400EE6D09 /* ORSSerialPortDemoController.m in Sources */,

--- a/Examples/ORSSerialPortDemo/Swift/ORSSerialPortDemo.xcodeproj/project.pbxproj
+++ b/Examples/ORSSerialPortDemo/Swift/ORSSerialPortDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2788B8031BA05F3E0018C0E7 /* ORSSerialBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2788B8021BA05F3E0018C0E7 /* ORSSerialBuffer.m */; settings = {ASSET_TAGS = (); }; };
 		9D0E21661A0441F500051960 /* SerialPortDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0E21651A0441F500051960 /* SerialPortDemoController.swift */; };
 		9D0E21681A04460000051960 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9D0E21671A04460000051960 /* MainMenu.xib */; };
 		9DFD06401A043BF300CE0294 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9DFD063B1A043BF300CE0294 /* Images.xcassets */; };
@@ -16,6 +17,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2788B8011BA05F3E0018C0E7 /* ORSSerialBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORSSerialBuffer.h; sourceTree = "<group>"; };
+		2788B8021BA05F3E0018C0E7 /* ORSSerialBuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORSSerialBuffer.m; sourceTree = "<group>"; };
 		9D0E21651A0441F500051960 /* SerialPortDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SerialPortDemoController.swift; sourceTree = "<group>"; };
 		9D0E21671A04460000051960 /* MainMenu.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainMenu.xib; sourceTree = "<group>"; };
 		9DFD06181A043BA400CE0294 /* ORSSerialPortDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ORSSerialPortDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -85,6 +88,8 @@
 				9DFD064E1A043D3600CE0294 /* ORSSerialPort.m */,
 				9DFD06501A043D5500CE0294 /* ORSSerialPortManager.h */,
 				9DFD06511A043D5500CE0294 /* ORSSerialPortManager.m */,
+				2788B8011BA05F3E0018C0E7 /* ORSSerialBuffer.h */,
+				2788B8021BA05F3E0018C0E7 /* ORSSerialBuffer.m */,
 			);
 			name = ORSSerialPort;
 			path = ../../../Source;
@@ -165,6 +170,7 @@
 				9DFD06421A043BF300CE0294 /* AppDelegate.swift in Sources */,
 				9DFD064F1A043D3600CE0294 /* ORSSerialPort.m in Sources */,
 				9D0E21661A0441F500051960 /* SerialPortDemoController.swift in Sources */,
+				2788B8031BA05F3E0018C0E7 /* ORSSerialBuffer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
- Add missing `ORSSerialBuffer` concerns to `ORSSerialPortDemo` and `CommandLineDemo`
- Update `print` to use `terminator:` argument as opposed to defunct `appendNewline:`

Performed under Xcode7 beta-6 