### PR TITLE
Refactor buffer parsing to serial packet descriptor

### DIFF
--- a/Source/ORSSerialPacketDescriptor.h
+++ b/Source/ORSSerialPacketDescriptor.h
@@ -183,6 +183,15 @@ typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
 - (BOOL)dataIsValidPacket:(nullable NSData *)packetData;
 
 /**
+ *  Can be used to determine and extract a packet from a buffer, matching up to the end of the buffer.
+ *
+ *  @param buffer Data received from serial port.
+ *
+ *  @return Data corresponding to valid packet, or nil.
+ */
+- (nullable NSData *)packetMatchingAtEndOfBuffer:(nullable NSData *)buffer;
+
+/**
  *  The fixed packetData for packets described by the receiver. Will be nil for packet
  *  descriptors not created using -initWithPacketData:userInfo:
  */

--- a/Source/ORSSerialPacketDescriptor.m
+++ b/Source/ORSSerialPacketDescriptor.m
@@ -137,4 +137,14 @@
 	return self.responseEvaluator(packetData);
 }
 
+- (NSData *)packetMatchingAtEndOfBuffer:(NSData *)buffer
+{
+    for (NSUInteger i=1; i<=[buffer length]; i++)
+    {
+        NSData *window = [buffer subdataWithRange:NSMakeRange([buffer length]-i, i)];
+        if ([self dataIsValidPacket:window]) return window;
+    }
+    return nil;
+}
+
 @end

--- a/Source/ORSSerialPacketDescriptor.m
+++ b/Source/ORSSerialPacketDescriptor.m
@@ -139,12 +139,12 @@
 
 - (NSData *)packetMatchingAtEndOfBuffer:(NSData *)buffer
 {
-    for (NSUInteger i=1; i<=[buffer length]; i++)
-    {
-        NSData *window = [buffer subdataWithRange:NSMakeRange([buffer length]-i, i)];
-        if ([self dataIsValidPacket:window]) return window;
-    }
-    return nil;
+	for (NSUInteger i=1; i<=[buffer length]; i++)
+	{
+		NSData *window = [buffer subdataWithRange:NSMakeRange([buffer length]-i, i)];
+		if ([self dataIsValidPacket:window]) return window;
+	}
+	return nil;
 }
 
 @end

--- a/Source/ORSSerialPort.m
+++ b/Source/ORSSerialPort.m
@@ -475,17 +475,6 @@ static __strong NSMutableArray *allSerialPorts;
 #pragma mark - Private Methods
 
 // Must only be called on requestHandlingQueue (ie. wrap call to this method in dispatch())
-- (NSData *)packetMatchingDescriptor:(ORSSerialPacketDescriptor *)descriptor atEndOfBuffer:(NSData *)buffer
-{
-	for (NSUInteger i=1; i<=[buffer length]; i++)
-	{
-		NSData *window = [buffer subdataWithRange:NSMakeRange([buffer length]-i, i)];
-		if ([descriptor dataIsValidPacket:window]) return window;
-	}
-	return nil;
-}
-
-// Must only be called on requestHandlingQueue (ie. wrap call to this method in dispatch())
 - (BOOL)reallySendRequest:(ORSSerialRequest *)request
 {
 	if (!self.pendingRequest)
@@ -558,7 +547,7 @@ static __strong NSMutableArray *allSerialPorts;
 	}
 	
 	[self.requestResponseReceiveBuffer appendData:byte];
-	NSData *responseData = [self packetMatchingDescriptor:packetDescriptor atEndOfBuffer:self.requestResponseReceiveBuffer.data];
+    NSData *responseData = [packetDescriptor packetMatchingAtEndOfBuffer:self.requestResponseReceiveBuffer.data];
 	if (!responseData) return;
 	
 	self.pendingRequestTimeoutTimer = nil;
@@ -600,7 +589,7 @@ static __strong NSMutableArray *allSerialPorts;
 				[buffer appendData:byte];
 				
 				// Check for complete packet
-				NSData *completePacket = [self packetMatchingDescriptor:descriptor atEndOfBuffer:buffer.data];
+				NSData *completePacket = [descriptor packetMatchingAtEndOfBuffer:buffer.data];
 				if (![completePacket length]) continue;
 				
 				// Complete packet received, so notify delegate then clear buffer

--- a/Source/ORSSerialPort.m
+++ b/Source/ORSSerialPort.m
@@ -547,7 +547,7 @@ static __strong NSMutableArray *allSerialPorts;
 	}
 	
 	[self.requestResponseReceiveBuffer appendData:byte];
-    NSData *responseData = [packetDescriptor packetMatchingAtEndOfBuffer:self.requestResponseReceiveBuffer.data];
+	NSData *responseData = [packetDescriptor packetMatchingAtEndOfBuffer:self.requestResponseReceiveBuffer.data];
 	if (!responseData) return;
 	
 	self.pendingRequestTimeoutTimer = nil;


### PR DESCRIPTION
I came across a similar situation to that described in issue #89 and issue #90, which inspired this pull request. By moving the buffer packet parsing into the ORSSerialPacketDescriptor object, this opens up greater extensibility. This should remain both backwards compatible with existing implementations, but open up new possibilities by subclassing `ORSSerialPacketDescriptor` to do more complex matching (such as purely delimited packet matching).

This may not be the perfect solution, but I wanted to propose a potential solution (and start using it in my own project). If you would rather take a different approach or focus on the Swift rewrite, I completely understand.

I did not include an example or a built-in class taking advantage of the new functionality, but can do so if that would be helpful. You can see how I am using it in this gist, which includes a generic delimited packet descriptor class (written in Swift) and a basic set of tests:

https://gist.github.com/nathanntg/2ad76f9db61d33f88229