### PR TITLE
[SerialPort] existing port must be the same device

### DIFF
--- a/Framework Project/ORSSerialPort.xcodeproj/project.pbxproj
+++ b/Framework Project/ORSSerialPort.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 		9DCA89091A2BB106009285EB /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Open Reel Software";
 				TargetAttributes = {
 					9D7472121B6D7767002D8B10 = {
@@ -234,10 +234,11 @@
 			};
 			buildConfigurationList = 9DCA890C1A2BB106009285EB /* Build configuration list for PBXProject "ORSSerialPort" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 9DCA89081A2BB106009285EB;
 			productRefGroup = 9DCA89131A2BB106009285EB /* Products */;
@@ -342,6 +343,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -397,6 +399,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/Framework Project/ORSSerialPort.xcodeproj/xcshareddata/xcschemes/ORSSerial.xcscheme
+++ b/Framework Project/ORSSerialPort.xcodeproj/xcshareddata/xcschemes/ORSSerial.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/ORSSerialPort.m
+++ b/Source/ORSSerialPort.m
@@ -160,7 +160,7 @@ static __strong NSMutableArray *allSerialPorts;
 	NSString *bsdPath = [[self class] bsdCalloutPathFromDevice:device];
 	ORSSerialPort *existingPort = [[self class] existingPortWithPath:bsdPath];
 	
-	if (existingPort != nil)
+	if (existingPort != nil && IOObjectIsEqualTo(_IOKitDevice, device))
 	{
 		self = nil;
 		return existingPort;


### PR DESCRIPTION
Comparing only the `path` between an existing port and a new port is not enough when considering equality. Doing so causes the `ORSSerialPortManager` to keep ports with valid paths, but
with invalid (terminated) `IOKitDevice` objects, thus making subsequent calls to `IORegistryEntryCreateIterator` ineffectual.

---
Shown below is my own output for [this code example](https://github.com/armadsen/ORSSerialPort/wiki/Getting-Vendor-ID-and-Product-ID) to retrieve product and vendor IDs. After being removed at least once, calls to the `IORegistryEntryCreateCFProperties` function will no longer return any attributes for the port's `IOKitDevice`, since that object has become invalid (terminated). Yet, KVO changes on `availablePorts` continue to include the `ORSSerialPort` port, so long as it is connected to the same `path`.

 - `1` is the `rawValue` for the KVO `Kind` change;
 - `/dev/cu.usbserial-1410` is the port's `path`;
 - the tuple is `kUSBProductID` & `kUSBVendorID`, respectively; and
 - `48643` is the `io_object_t`'s numeric value.

> _Note: I'm defaulting to `NSNotFound` when ID values return `nil`._

```
1 /dev/cu.usbserial-1410 (29987, 6790) 48643
2 /dev/cu.usbserial-1410 (9223372036854775807, 9223372036854775807) 48643
```

However, when applying this change, `IORegistryEntryCreateIterator` will work correctly:

```
1 /dev/cu.usbserial-1410 (29987, 6790) 48643
2 /dev/cu.usbserial-1410 (29987, 6790) 59155
```
Notice that the `io_object_t`'s numeric value has been changed to the valid (connected) port, and that the product and vendor ID's are now correct. The `path` hasn't changed.