### PR TITLE
Add initializer to ORSSerialPacketDescriptor to allow for choosing matching options on a regular expression

### DIFF
--- a/Source/ORSSerialPacketDescriptor.h
+++ b/Source/ORSSerialPacketDescriptor.h
@@ -153,7 +153,7 @@ typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
 							userInfo:(nullable id)userInfo;
 
 /**
- *  Creates an initializes an ORSSerialPacketDescriptor instance using a regular expression.
+ *  Creates an initializes an ORSSerialPacketDescriptor instance using a regular expression. This is a convenience initializer that calls initWithRegularExpression:matchingOptions:maximumPacketLength:userInfo: with the matching options argument as NSMatchingAnchored.
  *
  *  A packet is considered valid as long as it contains at least one match for the provided
  *  regular expression. For this reason, the regex should match as conservatively (smallest match) as possible.
@@ -171,6 +171,30 @@ typedef BOOL(^ORSSerialPacketEvaluator)(NSData * __nullable inputData);
 - (instancetype)initWithRegularExpression:(NSRegularExpression *)regex
 					  maximumPacketLength:(NSUInteger)maxPacketLength
 								 userInfo:(nullable id)userInfo;
+
+/**
+*  Creates an initializes an ORSSerialPacketDescriptor instance using a regular expression.
+*
+*  A packet is considered valid as long as it contains at least one match for the provided
+*  regular expression. For this reason, the regex should match as conservatively (smallest match) as possible.
+*
+*  Packets described by descriptors created using this method are assumed to be ASCII or UTF8 strings.
+*  If your packets are not naturally represented as strings, consider using
+*  -initWithMaximumPacketLength:userInfo:responseEvaluator: instead.
+*
+*  @param regex    An NSRegularExpression instance for which valid packets are a match.
+*  @param options  The matching options the regular expression will use.
+*  @param maxPacketLength The maximum length of a valid packet. This value _must_ be correctly specified.
+*  @param userInfo An arbitrary userInfoObject. May be nil.
+*
+*  @return An initizliaized ORSSerialPacketDesciptor instance.
+*/
+
+- (instancetype)initWithRegularExpression:(NSRegularExpression *)regex
+                          matchingOptions:(NSMatchingOptions)options
+                      maximumPacketLength:(NSUInteger)maxPacketLength
+                                 userInfo:(nullable id)userInfo;
+
 
 /**
  *  Can be used to determine if a block of data is a valid packet matching the descriptor encapsulated

--- a/Source/ORSSerialPacketDescriptor.m
+++ b/Source/ORSSerialPacketDescriptor.m
@@ -110,16 +110,24 @@
 					  maximumPacketLength:(NSUInteger)maxPacketLength
 								 userInfo:(id)userInfo;
 {
-	self = [self initWithMaximumPacketLength:maxPacketLength userInfo:userInfo responseEvaluator:^BOOL(NSData *data) {
-		NSString *string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-		if (!string) return NO;
-		
-		return [regex numberOfMatchesInString:string options:NSMatchingAnchored range:NSMakeRange(0, [string length])] > 0;
-	}];
-	if (self) {
-		_regularExpression = regex;
-	}
-	return self;
+    return [self initWithRegularExpression:regex matchingOptions:NSMatchingAnchored maximumPacketLength:maxPacketLength userInfo:userInfo];
+}
+
+-(instancetype)initWithRegularExpression:(NSRegularExpression *)regex
+                         matchingOptions:(NSMatchingOptions)options
+                     maximumPacketLength:(NSUInteger)maxPacketLength
+                                userInfo:(id)userInfo
+{
+    self = [self initWithMaximumPacketLength:maxPacketLength userInfo:userInfo responseEvaluator:^BOOL(NSData *data) {
+        NSString *string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        if (!string) return NO;
+        
+        return [regex numberOfMatchesInString:string options:options range:NSMakeRange(0, [string length])] > 0;
+    }];
+    if (self) {
+        _regularExpression = regex;
+    }
+    return self;
 }
 
 - (BOOL)isEqual:(id)object


### PR DESCRIPTION
Context: I'm using ORSSerialPort to communicate with a home audio controller. The problem is that the responses come with the `#` prefix. The `NSMatchingAnchored` option prevents me from using a regular expression on responses that are returned on more than a single line. Or at least I haven't found a regular expression that will let me. 

In creating a new initializer that takes in the matching options, the user of ORSSerialPort can choose which options fit their use case. To maintain compatibility, the existing initializer that takes in a regular expression has been converted into a convenience initializer that calls the new initializer with `NSMatchingAnchored`.