### PR TITLE
Fix Xcode 12 errors

### DIFF
--- a/Source/ORSSerialPort.h
+++ b/Source/ORSSerialPort.h
@@ -125,6 +125,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface ORSSerialPort : NSObject
 
+    // missing interface to fix XCODE 12 errors.
+    + (io_object_t) deviceFromBSDPath:(NSString *)bsdPath;
+    + (NSString *) bsdCalloutPathFromDevice:(io_object_t)aDevice;
+    + (NSString *) modemNameFromDevice:(io_object_t)aDevice;
+    /**
+     *  ORSSerialPort must be init'd using -initWithPath:
+     */
+    - (instancetype) init;
+    - (void) reallyClosePort;
+
+    - (void) notifyDelegateOfPosixError;
+    - (void) notifyDelegateOfPosixErrorWaitingUntilDone:(BOOL)shouldWait;
+    - (void) setPortOptions;
+    - (void) updateModemLines;
+    - (void) receiveData:(NSData *)data;
+
 /** ---------------------------------------------------------------------------------------
  * @name Getting a Serial Port
  *  ---------------------------------------------------------------------------------------

--- a/Source/ORSSerialPort.m
+++ b/Source/ORSSerialPort.m
@@ -160,7 +160,7 @@ static __strong NSMutableArray *allSerialPorts;
 	NSString *bsdPath = [[self class] bsdCalloutPathFromDevice:device];
 	ORSSerialPort *existingPort = [[self class] existingPortWithPath:bsdPath];
 	
-    if (existingPort != nil && IOObjectIsEqualTo(_IOKitDevice, device)) {
+    if (existingPort != nil && IOObjectIsEqualTo(_IOKitDevice, device))
 	{
 		self = nil;
 		return existingPort;

--- a/Source/ORSSerialRequest.h
+++ b/Source/ORSSerialRequest.h
@@ -25,7 +25,10 @@
 //	SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import <ORSSerial/ORSSerialPacketDescriptor.h>
+
+//#import <ORSSerial/ORSSerialPacketDescriptor.h>
+// reference framework will not find it without framework. uncomment next line if not using framework.
+#import "ORSSerialPacketDescriptor.h"
 
 // Keep older versions of the compiler happy
 #ifndef NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
ORSSerialPort.h  one extra  { add in last commit in  - (instancetype)initWithDevice:(io_object_t)device; Line #163

Explained: ORSSerial/ORSSerialPacketDescriptor.h file not found in issue #169

defined the following in ORSSerialPort.h

// defined missing interface to fix XCODE 12.3 errors.
+ (io_object_t) deviceFromBSDPath:(NSString *)bsdPath;
+ (NSString *) bsdCalloutPathFromDevice:(io_object_t)aDevice;
+ (NSString *) modemNameFromDevice:(io_object_t)aDevice;
/**
 *  ORSSerialPort must be init'd using -initWithPath:
 */
- (instancetype) init;
- (void) reallyClosePort;

- (void) notifyDelegateOfPosixError;
- (void) notifyDelegateOfPosixErrorWaitingUntilDone:(BOOL)shouldWait;
- (void) setPortOptions;
- (void) updateModemLines;
- (void) receiveData:(NSData *)data;