### PR TITLE
allSerialPorts array crashes in multithreading

### DIFF
--- a/Source/ORSSerialPort.m
+++ b/Source/ORSSerialPort.m
@@ -102,37 +102,41 @@ static __strong NSMutableArray *allSerialPorts;
 
 + (void)addSerialPort:(ORSSerialPort *)port;
 {
-	[allSerialPorts addObject:[NSValue valueWithNonretainedObject:port]];
+    @synchronized (allSerialPorts) {
+        [allSerialPorts addObject:[NSValue valueWithNonretainedObject:port]];
+    }
 }
 
 + (void)removeSerialPort:(ORSSerialPort *)port;
 {
-	NSValue *valueToRemove = nil;
-	for (NSValue *value in allSerialPorts)
-	{
-		if ([value nonretainedObjectValue] == port)
-		{
-			valueToRemove = value;
-			break;
-		}
-	}
-	if (valueToRemove) [allSerialPorts removeObject:valueToRemove];
+    @synchronized(allSerialPorts){
+        NSValue *valueToRemove = nil;
+        for (NSValue *value in allSerialPorts)
+        {
+            if ([value nonretainedObjectValue] == port) {
+                valueToRemove = value;
+                break;
+            }
+        }
+        if (valueToRemove) [allSerialPorts removeObject:valueToRemove];
+    }
 }
 
 + (ORSSerialPort *)existingPortWithPath:(NSString *)path;
 {
-	ORSSerialPort *existingPort = nil;
-	for (NSValue *value in allSerialPorts)
-	{
-		ORSSerialPort *port = [value nonretainedObjectValue];
-		if ([port.path isEqualToString:path])
-		{
-			existingPort = port;
-			break;
-		}
-	}
-	
-	return existingPort;
+    ORSSerialPort *existingPort = nil;
+    @synchronized (allSerialPorts) {
+        for (NSValue *value in allSerialPorts)
+        {
+            ORSSerialPort *port = [value nonretainedObjectValue];
+            if ([port.path isEqualToString:path]) {
+                existingPort = port;
+                break;
+            }
+        }
+    }
+    
+    return existingPort;
 }
 
 + (ORSSerialPort *)serialPortWithPath:(NSString *)devicePath


### PR DESCRIPTION
allSerialPorts array crashes in multithreading


Application Specific Information:
*** Terminating app due to uncaught exception 'NSGenericException', reason: '*** Collection <__NSArrayM: 0x600003b3b120> was mutated while being enumerated.'
terminating with uncaught exception of type NSException
abort() called

Application Specific Backtrace 1:
0   CoreFoundation                      0x00007fff4029f035 __exceptionPreprocess + 256
1   libobjc.A.dylib                     0x00007fff6a9aba17 objc_exception_throw + 48
2   CoreFoundation                      0x00007fff403128be -[__NSSingleObjectEnumerator init] + 0
3   FW-Downloader                       0x00000001033831e5 +[ORSSerialPort removeSerialPort:] + 309
4   FW-Downloader                       0x0000000103384040 -[ORSSerialPort dealloc] + 64
5   FW-Downloader                       0x00000001033852e4 __21-[ORSSerialPort open]_block_invoke_2 + 1636
6   libdispatch.dylib                   0x00007fff6c12e63d _dispatch_client_callout + 8
7   libdispatch.dylib                   0x00007fff6c130de6 _dispatch_continuation_pop + 414
8   libdispatch.dylib                   0x00007fff6c13ff42 _dispatch_source_invoke + 2056
9   libdispatch.dylib                   0x00007fff6c13c3bc _dispatch_root_queue_drain + 324
10  libdispatch.dylib                   0x00007fff6c13cb46 _dispatch_worker_thread2 + 90
11  libsystem_pthread.dylib             0x00007fff6c36e6b3 _pthread_wqthread + 583
12  libsystem_pthread.dylib             0x00007fff6c36e3fd start_wqthread + 13