### PR TITLE
Fix the potential double delegate call per request

### DIFF
--- a/Sources/ORSSerialPort.m
+++ b/Sources/ORSSerialPort.m
@@ -517,6 +517,7 @@ static __strong NSMutableArray *allSerialPorts;
 // Will only be called on requestHandlingQueue
 - (void)pendingRequestDidTimeout
 {
+	if (!self.pendingRequestTimeoutTimer) return; // The request has already been handled
 	self.pendingRequestTimeoutTimer = nil;
 	
 	ORSSerialRequest *request = self.pendingRequest;
@@ -539,6 +540,7 @@ static __strong NSMutableArray *allSerialPorts;
 - (void)checkResponseToPendingRequestAndContinueIfValidWithReceivedByte:(NSData *)byte
 {
 	if (!self.pendingRequest) return; // Nothing to do
+	if (!self.pendingRequestTimeoutTimer) return; // The request has already timed out
 	
 	ORSSerialPacketDescriptor *packetDescriptor = self.pendingRequest.responseDescriptor;
 	


### PR DESCRIPTION
We've been facing a situation when both `requestDidTimeout` and `didReceiveResponse` were called for a single request. This might result in a crash when used e.g. with DispatchGroups to wait for the request completion.